### PR TITLE
Minor fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ ENV PATH=/opt/conda/bin:$PATH \
     CONDA_DEFAULT_ENV=root \
     CONDA_ENV_PATH=/opt/conda
 
+RUN conda install -y drmaa && \
+    conda clean -tipsy
+
 ADD docker /usr/share/docker
 RUN /usr/share/docker/install_tini.sh
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repo is part of an automated build, which is hosted on Docker Hub ( <https:
 
 ## Manual
 
-If one wishes to develop this repo, building will need to be performed manually. This container can be built simply by `cd`ing into the repo and using `docker build -t <NAME> .` where `<NAME>` is the name tagged to the image built. More information about building can be found in Docker's documentation ( <https://docs.docker.com/reference/builder> ). Please consider opening a pull request for changes that you make.
+If one wishes to develop this repo, building will need to be performed manually. This container can be built simply by `cd`ing into the repo and using `docker build --rm -t <NAME> .` where `<NAME>` is the name tagged to the image built. More information about building can be found in Docker's documentation ( <https://docs.docker.com/reference/builder> ). Please consider opening a pull request for changes that you make.
 
 # Testing
 
@@ -20,4 +20,4 @@ A simple test has been added during the installation of Grid Engine as this is t
 
 # Usage
 
-Once an image is acquired either from one of the provided builds or manually, the image is designed to provide a preconfigured shell environment. Simply run `docker run -it <NAME>`. This will configure Grid Engine and a number of environment variables useful for maintaining it and starts up `bash`. In the case of an automated build, `<NAME>` is `jakirkham/ubuntu_drmaa_conda`.
+Once an image is acquired either from one of the provided builds or manually, the image is designed to provide a preconfigured shell environment. Simply run `docker run --rm -it <NAME>`. This will configure Grid Engine and a number of environment variables useful for maintaining it and starts up `bash`. In the case of an automated build, `<NAME>` is `jakirkham/ubuntu_drmaa_conda`.

--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -30,8 +30,5 @@ conda install -y conda-build
 conda install -y anaconda-client
 conda install -y jinja2
 
-# Install drmaa to provide Python support for DRMAA.
-conda install -y drmaa
-
 # Clean out all unneeded intermediates.
 conda clean -yitps


### PR DESCRIPTION
- Move python `drmaa` package install out of miniconda installation and into the Dockerfile afterwards.
- Updates `docker` commands in README to encourage removal of intermediate containers.
