### PR TITLE
Update apt-get in miniconda install step

### DIFF
--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Update apt-get.
+apt-get update -y -q
+
 # Install curl to download the miniconda setup script.
 apt-get install -y curl
 


### PR DESCRIPTION
Makes sure `apt-get` is updated before proceeding in the miniconda installation step.
